### PR TITLE
fix: check capacity before free

### DIFF
--- a/cvlr-vectors/src/no_resizable_vec.rs
+++ b/cvlr-vectors/src/no_resizable_vec.rs
@@ -45,7 +45,7 @@ impl<T> RawVec<T> {
 impl<T> Drop for RawVec<T> {
     fn drop(&mut self) {
         // ZSTs have no memory allocation
-        if mem::size_of::<T>() == 0 {
+        if mem::size_of::<T>() == 0 || capacity == 0 {
             return;
         }
 


### PR DESCRIPTION
Since we create a raw vec when the capacity is 0, it's important to check this property when we are dropping it