### PR TITLE
Align API with std:Vec and add Into/FromIterator traits

### DIFF
--- a/cvlr-vectors/src/no_resizable_vec.rs
+++ b/cvlr-vectors/src/no_resizable_vec.rs
@@ -12,6 +12,7 @@ use std::{
 /////////////////////////
 /// Raw Vec
 /////////////////////////
+#[derive(Debug, Eq, PartialEq)]
 struct RawVec<T> {
     ptr: NonNull<T>,
     cap: usize,
@@ -59,12 +60,25 @@ impl<T> Drop for RawVec<T> {
 /////////////////////////
 /// NoResizableVec
 /////////////////////////
+#[derive(Debug, Eq, PartialEq)]
 pub struct NoResizableVec<T> {
     buf: RawVec<T>,
     len: usize,
 }
 
+impl<T> Default for NoResizableVec<T>{
+    fn default() -> Self {
+        Self::new_zero_sized()
+    }
+}
+
 impl<T> NoResizableVec<T> {
+    
+    pub fn new_zero_sized() -> Self {
+        //Set default capacity to 10
+        Self::new(10)
+    }
+
     pub fn new(capacity: usize) -> Self {
         Self {
             buf: RawVec::new(capacity),

--- a/cvlr-vectors/src/no_resizable_vec.rs
+++ b/cvlr-vectors/src/no_resizable_vec.rs
@@ -68,18 +68,18 @@ pub struct NoResizableVec<T> {
 
 impl<T> Default for NoResizableVec<T>{
     fn default() -> Self {
-        Self::new_zero_sized()
+        Self::new()
     }
 }
 
 impl<T> NoResizableVec<T> {
     
-    pub fn new_zero_sized() -> Self {
+    pub fn new() -> Self {
         //Set default capacity to 10
-        Self::new(10)
+        Self::with_capacity(10)
     }
 
-    pub fn new(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             buf: RawVec::new(capacity),
             len: 0,
@@ -358,7 +358,7 @@ macro_rules! cvt_no_resizable_vec {
     ($(values:expr),+ $(,)?) => (
         {
             let ARG_COUNT: usize = 0 $(+ { _ = $values; 1 })*;
-            let mut v = $crate::no_resizable_vec::NoResizableVec::new(ARG_COUNT*2);
+            let mut v = $crate::no_resizable_vec::NoResizableVec::with_capacity(ARG_COUNT*2);
             $(v.push($values);)*
             v
         }
@@ -368,7 +368,7 @@ macro_rules! cvt_no_resizable_vec {
         {
             let ARG_COUNT: usize = 0 $(+ { _ = $values; 1 })*;
             cvlr::asserts::cvlr_assert!(ARG_COUNT <= $cap);
-            let mut v = $crate::no_resizable_vec::NoResizableVec::new($cap);
+            let mut v = $crate::no_resizable_vec::NoResizableVec::with_capacity($cap);
             $(v.push($values);)*
             v
         }
@@ -383,7 +383,7 @@ mod test {
 
     #[test]
     fn test_push_and_pop() {
-        let mut vec = NoResizableVec::new(3);
+        let mut vec = NoResizableVec::with_capacity(3);
         vec.push(1);
         vec.push(2);
         vec.push(3);
@@ -397,7 +397,7 @@ mod test {
 
     #[test]
     fn test_insert_and_remove() {
-        let mut vec = NoResizableVec::new(3);
+        let mut vec = NoResizableVec::with_capacity(3);
         vec.push(1);
         vec.push(3);
         vec.insert(1, 2);
@@ -415,7 +415,7 @@ mod test {
 
     #[test]
     fn test_find() {
-        let mut vec = NoResizableVec::new(3);
+        let mut vec = NoResizableVec::with_capacity(3);
         vec.push(10);
         vec.push(20);
         vec.push(30);
@@ -426,7 +426,7 @@ mod test {
 
     #[test]
     fn test_clone() {
-        let mut vec = NoResizableVec::new(3);
+        let mut vec = NoResizableVec::with_capacity(3);
         vec.push(1);
         vec.push(2);
         vec.push(3);
@@ -440,7 +440,7 @@ mod test {
 
     #[test]
     fn test_into_iter() {
-        let mut vec = NoResizableVec::new(3);
+        let mut vec = NoResizableVec::with_capacity(3);
         vec.push(1);
         vec.push(2);
         vec.push(3);
@@ -454,7 +454,7 @@ mod test {
 
     #[test]
     fn test_bin_search1() {
-        let mut vec: NoResizableVec<u64> = NoResizableVec::new(3);
+        let mut vec: NoResizableVec<u64> = NoResizableVec::with_capacity(3);
 
         vec.push(5);
         vec.push(15);
@@ -484,7 +484,7 @@ mod test {
 
     #[test]
     fn test_bin_search2() {
-        let mut vec: NoResizableVec<u64> = NoResizableVec::new(3);
+        let mut vec: NoResizableVec<u64> = NoResizableVec::with_capacity(3);
         vec.push(4);
         vec.push(7);
         vec.push(9);
@@ -513,7 +513,7 @@ mod test {
 
     #[test]
     pub fn test_bin_search3() {
-        let mut vec: NoResizableVec<u64> = NoResizableVec::new(3);
+        let mut vec: NoResizableVec<u64> = NoResizableVec::with_capacity(3);
 
         let v1: u64 = 5;
         let v2: u64 = 15;
@@ -547,8 +547,8 @@ mod test {
 
     #[test]
     fn test_bin_search4() {
-        let mut vec1: NoResizableVec<u64> = NoResizableVec::new(3);
-        let mut vec2: NoResizableVec<u64> = NoResizableVec::new(3);
+        let mut vec1: NoResizableVec<u64> = NoResizableVec::with_capacity(3);
+        let mut vec2: NoResizableVec<u64> = NoResizableVec::with_capacity(3);
 
         let v1: u64 = 5;
         let v2: u64 = 15;

--- a/cvlr-vectors/src/no_resizable_vec.rs
+++ b/cvlr-vectors/src/no_resizable_vec.rs
@@ -66,14 +66,13 @@ pub struct NoResizableVec<T> {
     len: usize,
 }
 
-impl<T> Default for NoResizableVec<T>{
+impl<T> Default for NoResizableVec<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl<T> NoResizableVec<T> {
-    
     pub fn new() -> Self {
         //Set default capacity to 10
         Self::with_capacity(10)
@@ -157,15 +156,11 @@ impl<T> NoResizableVec<T> {
     }
 
     pub fn as_slice(&self) -> &[T] {
-        unsafe {
-            std::slice::from_raw_parts(self.buf.ptr.as_ptr(), self.len)
-        }
+        unsafe { std::slice::from_raw_parts(self.buf.ptr.as_ptr(), self.len) }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        unsafe {
-            std::slice::from_raw_parts_mut(self.buf.ptr.as_mut(), self.len)
-        }
+        unsafe { std::slice::from_raw_parts_mut(self.buf.ptr.as_mut(), self.len) }
     }
 }
 
@@ -379,7 +374,6 @@ impl<'a, T> IntoIterator for &'a mut NoResizableVec<T> {
     }
 }
 
-
 impl<T> FromIterator<T> for NoResizableVec<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut vec = NoResizableVec::new();
@@ -389,7 +383,6 @@ impl<T> FromIterator<T> for NoResizableVec<T> {
         vec
     }
 }
-
 
 ////////////////////
 // Macros

--- a/cvlr-vectors/src/no_resizable_vec.rs
+++ b/cvlr-vectors/src/no_resizable_vec.rs
@@ -77,6 +77,14 @@ impl<T> NoResizableVec<T> {
         //Set default capacity to 10
         Self::with_capacity(10)
     }
+    
+    #[deprecated]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buf: RawVec::new(capacity),
+            len: 0,
+        }
+    }
 
     pub fn with_capacity(capacity: usize) -> Self {
         Self {

--- a/cvlr-vectors/src/no_resizable_vec.rs
+++ b/cvlr-vectors/src/no_resizable_vec.rs
@@ -155,6 +155,18 @@ impl<T> NoResizableVec<T> {
         }
         None
     }
+
+    pub fn as_slice(&self) -> &[T] {
+        unsafe {
+            std::slice::from_raw_parts(self.buf.ptr.as_ptr(), self.len)
+        }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe {
+            std::slice::from_raw_parts_mut(self.buf.ptr.as_mut(), self.len)
+        }
+    }
 }
 
 impl<T> Drop for NoResizableVec<T> {
@@ -348,6 +360,36 @@ impl<T> IntoIterator for NoResizableVec<T> {
         }
     }
 }
+
+impl<'a, T> IntoIterator for &'a NoResizableVec<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_slice().iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut NoResizableVec<T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_mut_slice().iter_mut()
+    }
+}
+
+
+impl<T> FromIterator<T> for NoResizableVec<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut vec = NoResizableVec::new();
+        for item in iter {
+            vec.push(item);
+        }
+        vec
+    }
+}
+
 
 ////////////////////
 // Macros

--- a/cvlr-vectors/src/no_resizable_vec.rs
+++ b/cvlr-vectors/src/no_resizable_vec.rs
@@ -77,14 +77,6 @@ impl<T> NoResizableVec<T> {
         //Set default capacity to 10
         Self::with_capacity(10)
     }
-    
-    #[deprecated]
-    pub fn new(capacity: usize) -> Self {
-        Self {
-            buf: RawVec::new(capacity),
-            len: 0,
-        }
-    }
 
     pub fn with_capacity(capacity: usize) -> Self {
         Self {


### PR DESCRIPTION
This PR adds a few additions to our NoResizableVec:

* Add the derive macros `Debug`, `Eq`, `PartialEq` to be usable more versatile.
* Add `IntoIterator` and `FromIterator` traits so that it's possible to use `NoResizableVec` as an iterator.
* Renamed `new(capacity)` to `with_capacity(capacity)` to comply with `std:Vec` implementation - this allows easier replacement in existing code bases that use `std:Vec` with `NoResizableVec` without additional changes. 